### PR TITLE
Add game.type property to presence

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -105,6 +105,7 @@ bot.on("guildMemberRemove", member => {
 function setGame() {
     var presence = {};
     presence.game = {};
+    presence.game.type = 0;
     presence.status = "online";
     presence.afk = false;
     


### PR DESCRIPTION
In a recent Discord API update, the type property became required for Game objects. This caused some bots to stop correctly displaying games. This pull request fixes that by adding the type property, and should lead to ProJshBot displaying game messages correctly again.